### PR TITLE
Use gitlab-ci to automate the image rebuilds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,49 @@
+image: docker:latest
+services:
+    - docker:dind
+
+stages:
+    - base
+    - runtimes
+
+# Expects $IMAGE which should be the name+tag of the registry image.
+# Expects $OCI_YML variable which should be the path to the dockerfile
+.base_template: &base_build
+    script:
+        - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
+        - docker build --pull -f ${OCI_YML} -t ${IMAGE} .
+        # For debugging
+        - echo ${IMAGE}
+        - docker push ${IMAGE}
+    only:
+        - master
+        - triggers
+        - schedules
+
+base:
+    stage: base
+    before_script:
+        - export IMAGE="${CI_REGISTRY}/${CI_PROJECT_NAMESPACE}/${CI_PROJECT_NAME}/base"
+        - export OCI_YML=Dockerfile
+    <<: *base_build
+
+fdo:1.6:
+    stage: runtimes
+    before_script:
+        - export IMAGE="${CI_REGISTRY}/${CI_PROJECT_NAMESPACE}/${CI_PROJECT_NAME}/freedesktop:1.6"
+        - export OCI_YML=freedesktop-1-6/Dockerfile
+    <<: *base_build
+
+gnome:3.26:
+    stage: runtimes
+    before_script:
+        - export IMAGE="${CI_REGISTRY}/${CI_PROJECT_NAMESPACE}/${CI_PROJECT_NAME}/gnome:3.26"
+        - export OCI_YML=gnome-3-26/Dockerfile
+    <<: *base_build
+
+gnome:3.28:
+    stage: runtimes
+    before_script:
+        - export IMAGE="${CI_REGISTRY}/${CI_PROJECT_NAMESPACE}/${CI_PROJECT_NAME}/gnome:3.28"
+        - export OCI_YML=gnome-3-28/Dockerfile
+    <<: *base_build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:27
+FROM fedora:latest
 MAINTAINER Alexander Larsson <alexl@redhat.com>
 VOLUME /build
 WORKDIR /build


### PR DESCRIPTION
2a80d6a465bf7e6bcee5871b49b3ccd10a16b6f1 Configures a gitlab-ci runner to build the images and push them to the registry associated with that repo/mirror

4050d0f9b472c97e85105ed4fd39ee7f1cdfc39a Updates the base image to track the latest stable fedora releases