### PR TITLE
[WIP] Updating to latest versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
-FROM fedora:27
-MAINTAINER Alexander Larsson <alexl@redhat.com>
+FROM fedora:32
 VOLUME /build
 WORKDIR /build
 ENV FLATPAK_GL_DRIVERS=dummy
 RUN dnf -y update && dnf install -y flatpak-builder ostree fuse elfutils dconf git bzr && dnf clean all
 RUN flatpak remote-add flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-RUN flatpak remote-add gnome-nightly https://sdk.gnome.org/gnome-nightly.flatpakrepo
-RUN flatpak remote-add gnome https://sdk.gnome.org/gnome.flatpakrepo

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,16 @@
-all: build-base build-freedesktop-1-6 build-gnome-3-26 build-gnome-3-28
+all: build-base build-freedesktop build-gnome build-kde
 
 build-base:
 	docker build --pull -t flatpak/flatpak-builder:base .
 
-build-freedesktop-1-6:
-	docker build -f freedesktop-1-6/Dockerfile --no-cache -t flatpak/flatpak-builder:freedesktop-1-6 .
+FREEDESKTOP_VERSION=19.08
+build-freedesktop: build-base
+	docker build -f freedesktop/Dockerfile --no-cache --build-arg VERSION=${FREEDESKTOP_VERSION} -t flatpak/flatpak-builder:freedesktop-$(subst .,-,${FREEDESKTOP_VERSION}) .
 
-build-gnome-3-26:
-	docker build -f gnome-3-26/Dockerfile --no-cache -t flatpak/flatpak-builder:gnome-3-26 .
+GNOME_VERSION=3.36
+build-gnome: build-base
+	docker build -f gnome/Dockerfile --no-cache --build-arg VERSION=${GNOME_VERSION} -t flatpak/flatpak-builder:gnome-$(subst .,-,${GNOME_VERSION}) .
 
-build-gnome-3-28:
-	docker build -f gnome-3-28/Dockerfile --no-cache -t flatpak/flatpak-builder:gnome-3-28 .
-
-push:
-	docker tag flatpak/flatpak-builder:base docker.io/flatpak/flatpak-builder:base
-	docker push docker.io/flatpak/flatpak-builder:base
-	docker tag flatpak/flatpak-builder:freedesktop-1-6 docker.io/flatpak/flatpak-builder:freedesktop-1-6
-	docker push docker.io/flatpak/flatpak-builder:freedesktop-1-6
-	docker tag flatpak/flatpak-builder:gnome-3-26 docker.io/flatpak/flatpak-builder:gnome-3-26
-	docker push docker.io/flatpak/flatpak-builder:gnome-3-26
-	docker tag flatpak/flatpak-builder:gnome-3-28 docker.io/flatpak/flatpak-builder:gnome-3-28
-	docker push docker.io/flatpak/flatpak-builder:gnome-3-28
+KDE_VERSION=5.14
+build-kde: build-base
+	docker build -f kde/Dockerfile --no-cache --build-arg VERSION=${KDE_VERSION} -t flatpak/flatpak-builder:kde-$(subst .,-,${KDE_VERSION}) .

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Docker images for flatpak builder
+
+## Run
+
+    docker run -it --rm \
+      --name flatpak-builder \
+      --privileged \
+      -v /path/to/project:/build \
+      flatpak/flatpak-builder:freedesktop-19.08 \
+      flatpak-builder --disable-rofiles-fuse --disable-cache --force-clean --repo="$FLATPAK_REPO" "$FLATPAK_BUILD_FOLDER" "$FLATPAK_JSON_FILE".json;

--- a/freedesktop-1-6/Dockerfile
+++ b/freedesktop-1-6/Dockerfile
@@ -1,3 +1,0 @@
-FROM flatpak/flatpak-builder:base
-MAINTAINER Alexander Larsson <alexl@redhat.com>
-RUN flatpak install flathub org.freedesktop.Sdk//1.6 org.freedesktop.Platform//1.6

--- a/freedesktop/Dockerfile
+++ b/freedesktop/Dockerfile
@@ -1,0 +1,3 @@
+FROM flatpak/flatpak-builder:base
+ARG VERSION
+RUN flatpak install -y flathub org.freedesktop.Sdk//$VERSION org.freedesktop.Platform//$VERSION

--- a/gnome-3-26/Dockerfile
+++ b/gnome-3-26/Dockerfile
@@ -1,3 +1,0 @@
-FROM flatpak/flatpak-builder:freedesktop-1-6
-MAINTAINER Alexander Larsson <alexl@redhat.com>
-RUN flatpak install flathub org.gnome.Sdk//3.26 org.gnome.Platform//3.26

--- a/gnome-3-28/Dockerfile
+++ b/gnome-3-28/Dockerfile
@@ -1,3 +1,0 @@
-FROM flatpak/flatpak-builder:freedesktop-1-6
-MAINTAINER Alexander Larsson <alexl@redhat.com>
-RUN flatpak install gnome org.gnome.Sdk//3.28 org.gnome.Platform//3.28

--- a/gnome/Dockerfile
+++ b/gnome/Dockerfile
@@ -1,0 +1,3 @@
+FROM flatpak/flatpak-builder:base
+ARG VERSION
+RUN flatpak install -y flathub org.gnome.Sdk//$VERSION org.gnome.Platform//$VERSION

--- a/kde/Dockerfile
+++ b/kde/Dockerfile
@@ -1,0 +1,3 @@
+FROM flatpak/flatpak-builder:base
+ARG VERSION
+RUN flatpak install -y flathub org.kde.Sdk//$VERSION org.kde.Platform//$VERSION


### PR DESCRIPTION
Versions:
- Fedora 32
- Freedesktop 19.08
- Gnome 3.36
- KDE 5.14

Known problems:
- seccomp file is not working with latest builder (bwrap: Failed to make / slave: Permission denied)  
  See flatpak/flatpak#3027 for a discussion on unprivileged execution
- Running docker with --user isn't implemented

Fixes #2